### PR TITLE
Add support for asar 1.91

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 The best syntax highlighter for [Asar](https://github.com/RPGHacker/asar) projects in VS Code.
 
 ## Features
-- Support for every function and directives in Asar 1.81
+- Support for every function and directives in Asar 1.91
 - Support for 65c816, SPC700 and GSU/Super FX mnemonics
 - Custom scopes for literally everything supported
 - (Hopefully) smarter than the current options at the extensions marketplace
@@ -13,7 +13,7 @@ Check the `samples` folder contents for some live previews of the highlighter.
 Some color settings have their own previews in `user-settings` folder's README.md file, you can check them out there.
 
 ## Extra info
-You can check which scopes are affecting the text in the file by using `Developer: Inspect Editior Tokens and Scopes` in the command palette in VS Code.
+You can check which scopes are affecting the text in the file by using `Developer: Inspect Editor Tokens and Scopes` in the command palette in VS Code.
 
 ## Bugs
 See the [current issues](https://github.com/TheLX5/AsarSyntaxHighlight-VSCode/issues) in order to check what's missing or doesn't work.

--- a/asarsyntaxhighlighter/changelog.md
+++ b/asarsyntaxhighlighter/changelog.md
@@ -1,3 +1,6 @@
+# Version 1.0.3
+- Now supports asar 1.91
+
 # Version 1.0.2
 - Fixed macro labels not being captured in a scope if they're missing : at the end
 

--- a/asarsyntaxhighlighter/package.json
+++ b/asarsyntaxhighlighter/package.json
@@ -5,7 +5,7 @@
 	"publisher": "lx5",
 	"icon": "asar.ico",
 	"description": "Syntax highlighter for Asar, a SNES assembler with support for 65c816, SPC700 and GSU mnemonics.",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"repository": {
 		"url": "https://github.com/TheLX5/AsarSyntaxHighlight-VSCode"
 	},

--- a/asarsyntaxhighlighter/readme.md
+++ b/asarsyntaxhighlighter/readme.md
@@ -5,13 +5,13 @@ Official GitHub Repo: https://github.com/TheLX5/AsarSyntaxHighlight-VSCode
 The best syntax highlighter for [Asar](https://github.com/RPGHacker/asar) projects.
 
 ## Features
-- Support for every function and directive in Asar 1.81
+- Support for every function and directive in Asar 1.91
 - Support for 65c816, SPC700 and GSU mnemonics
 - Custom scopes for literally everything supported
 - (Hopefully) smarter than the current options at the extensions marketplace
 
 ## Extra info
-You can check which scopes are affecting the text in the file by using `Developer: Inspect Editior Tokens and Scopes` in the command palette in VS Code.
+You can check which scopes are affecting the text in the file by using `Developer: Inspect Editor Tokens and Scopes` in the command palette in VS Code.
 
 ## Previews
 Check the [samples folder](https://github.com/TheLX5/AsarSyntaxHighlight-VSCode/tree/master/samples) contents for some live previews of the highlighter.

--- a/asarsyntaxhighlighter/syntaxes/asar.tmLanguage
+++ b/asarsyntaxhighlighter/syntaxes/asar.tmLanguage
@@ -128,8 +128,21 @@
 			<string>Asar macro arguments</string>
 			<key>name</key>
 			<string>keyword.asar.macro.args.usage</string>
-			<key>match</key>
-			<string><[a-zA-Z_0-9]+></string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>name</key>
+					<string>keyword.asar.macro.args.usage</string>
+					<key>match</key>
+					<string><[a-zA-Z_0-9]+></string>
+				</dict>
+				<dict>
+					<key>name</key>
+					<string>keyword.asar.macro.args.usage.variadic</string>
+					<key>match</key>
+					<string><\.{3}(\[\S+\])?></string>
+				</dict>
+			</array>
 		</dict>
 
 
@@ -552,11 +565,27 @@
 		</dict>
 		<dict>
 			<key>comment</key>
+			<string>Asar macro functions</string>
+			<key>match</key>
+			<string>(?i)\s*(sizeof)(?=\(\.{3}\))</string>
+			<key>name</key>
+			<string>keyword.asar.functions.macro</string>
+		</dict>
+		<dict>
+			<key>comment</key>
 			<string>Asar string functions</string>
 			<key>match</key>
 			<string>(?i)\s*_?(stringsequal|stringsequalnocase)(?=\()</string>
 			<key>name</key>
 			<string>keyword.asar.functions.string</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Asar address functions</string>
+			<key>match</key>
+			<string>(?i)\s*_?(pc|realbase)(?=\()</string>
+			<key>name</key>
+			<string>keyword.asar.functions.address</string>
 		</dict>
 		<dict>
 			<key>comment</key>
@@ -603,7 +632,7 @@
 			<key>comment</key>
 			<string>Asar architecture directives</string>
 			<key>match</key>
-			<string>(?i)\s*\b(arch)\b[\s]+\b(65816|spc700\-inline|spc700|superfx)</string>
+			<string>(?i)\s*\b(arch)\b[\s]+\b(65816|spc700|superfx)$</string>
 			<key>name</key>
 			<string>keyword.asar.arch</string>
 		</dict>
@@ -626,7 +655,7 @@
 			<key>comment</key>
 			<string>Asar warning directives</string>
 			<key>match</key>
-			<string>(?i)\s*\b(warnings\s+(push|pull|((enable|disable)\b\s+[W|w][0-9]+)))\b\s*</string>
+			<string>\s*\b(warnings\s+(push|pull|((enable|disable)\b\s+W\w+)))\b\s*</string>
 			<key>name</key>
 			<string>keyword.asar.warnings</string>
 		</dict>
@@ -638,7 +667,7 @@
 			<key>comment</key>
 			<string>Asar compatibility directives</string>
 			<key>match</key>
-			<string>(?i)\s*\b(warn\s+xkas\s+(on|off)|math\s+pri\s+(on|off)|math\s+round\s+(on|off)|namespace\s+nested\s+(on|off))\b\s*</string>
+			<string>(?i)\s*\b(warn\s+xkas\s+(on|off)|math\s+pri\s+(on|off)|math\s+round\s+(on|off)|namespace\s+nested\s+(on|off)|asar\s([\d\.]+))\b\s*</string>
 			<key>name</key>
 			<string>keyword.asar.compatibility</string>
 		</dict>
@@ -687,7 +716,7 @@
 			<key>comment</key>
 			<string>Asar freespace directives</string>
 			<key>match</key>
-			<string>(?i)\s*\b(freecode|freedata|freespace\b\s+(ram|noram)?)\b\s*((\,*\s*(align|cleaned|static)\s*)+)?</string>
+			<string>(?i)\s*\b(freespacebyte|freecode|freedata|freespace\b\s+(ram|noram)?)\b\s*((\,*\s*(align|cleaned|static)\s*)+)?</string>
 			<key>name</key>
 			<string>keyword.asar.freespace</string>
 		</dict>
@@ -708,7 +737,7 @@
 			<key>comment</key>
 			<string>Asar check directives</string>
 			<key>match</key>
-			<string>(?i)\s*\b(check\s+(title|bankcross\s+(on|off)))\b\s*</string>
+			<string>(?i)\s*\b(check\s+(title|bankcross\s+(full|half|off)))\b\s*</string>
 			<key>name</key>
 			<string>keyword.asar.checks</string>
 		</dict>
@@ -749,6 +778,14 @@
 				</dict>
 			</dict>
 		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Asar extra namespace directives</string>
+			<key>match</key>
+			<string>(?i)\s*\b(pushns|pullns)\b\s*</string>
+			<key>name</key>
+			<string>keyword.asar.namespace</string>
+		</dict>
 
 
 
@@ -757,7 +794,7 @@
 			<key>comment</key>
 			<string>Asar conditional function</string>
 			<key>match</key>
-			<string>(?i)\s*\b(if|while|else|elseif)\b\s*</string>
+			<string>(?i)\s*\b(if|while|for|else|elseif)\b\s*</string>
 			<key>name</key>
 			<string>keyword.asar.conditionals</string>
 		</dict>
@@ -765,9 +802,9 @@
 			<key>comment</key>
 			<string>Asar end conditional function</string>
 			<key>match</key>
-			<string>(?i)\s*\b(endif)\b\s*</string>
+			<string>(?i)\s*\b(endif|endwhile|endfor)\b\s*</string>
 			<key>name</key>
-			<string>keyword.asar.conditionals.endif</string>
+			<string>keyword.asar.conditionals.end</string>
 		</dict>
 
 
@@ -779,6 +816,25 @@
 			<string>keyword.asar.repeat</string>
 			<key>match</key>
 			<string>(?i)(\s*\b(rep)\b\s+)</string>
+		</dict>
+
+
+
+		<dict>
+			<key>comment</key>
+			<string>Asar inline SPC block</string>
+			<key>name</key>
+			<string>keyword.asar.spcblock</string>
+			<key>match</key>
+			<string>(?i)(\s*\b(spcblock)\b\s+)</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Asar inline SPC block ending</string>
+			<key>name</key>
+			<string>keyword.asar.spcblock.end</string>
+			<key>match</key>
+			<string>(?i)^\s*(endspcblock)\b\s*</string>
 		</dict>
 
 

--- a/samples/highlight_test.asm
+++ b/samples/highlight_test.asm
@@ -387,7 +387,7 @@ BRK : COP : WDM : STP
 ;################################################
 ;# CONDITIONALS
 
-; IF/WHILE/ELSE/ELSEIF conditionals
+; IF/WHILE/FOR/ELSE/ELSEIF conditionals
 ; Scope: keyword.asar.conditionals
 
 ; if, elseif, else and endif tests
@@ -406,7 +406,16 @@ endif
 while !i < 10
     lda.b #!i
     sta $00,x
-endif
+endwhile
+
+; for test
+
+for i = 1..5
+    lda.b #!i
+    sta $00+!i
+endfor
+
+for i = 0..10 : NOP : endfor
 
 ;################################################
 ;# BINARY DATA
@@ -439,6 +448,8 @@ fillword $DEAD
 filllong $0D9040 
 filldword $DEADBEEF
 fill 4
+fill align 8 offset 2
+fill align $08 offset $02
 
 ; Pad area with bytes
 ; Scope: keyword.asar.binary.pad
@@ -456,6 +467,7 @@ pad $01A005
 
 incbin "file.bin"
 incbin "file.bin":9-12
+incbin "file.bin":$9..$F
 
 ; Incbin operator
 ; Scope: keyword.asar.operator.incbin
@@ -526,6 +538,8 @@ endmacro
 %macro($0000, label, !define)   ; Calling a macro with arguments will use their respective scopes
 
 macro macro(a, ...)             ; Variadic macros are also supported
+	db sizeof(...), <...>, <...[0]>, <...[!i]>
+endmacro
 
 ; Some other valid macros
 
@@ -584,6 +598,18 @@ rep $10
 rep %10
 
 ;################################################
+;# SPCBLOCK
+
+; spcblock command
+; Scope: keyword.asar.spcblock
+
+spcblock $6000 nspc
+    db $00,$01,$02
+    exec_start:
+    mov $33,#$44
+endspcblock execute exec_start
+
+;################################################
 ;# NAMESPACES
 
 ; Namespaces
@@ -595,6 +621,9 @@ rep %10
 namespace prefix
 namespace off
 namespace               ; Requires a prefix or the "off" directive!
+
+pushns
+pullns
 
 ; Global labels
 ; Scope: keyword.asar.namespace.global
@@ -716,6 +745,12 @@ objectsize(identifier)
 stringsequal("yes", "no")
 stringsequalnocase("yes", "perhaps")	
 
+; Address related functions
+; Scope: keyword.asar.functions.address
+
+pc()
+realbase()
+
 ; Address conversion functions
 ; Scope: keyword.asar.functions.convert
 
@@ -780,6 +815,7 @@ error "string"
 
 assert 
 assert !define == $23, "string"
+assert pc() <= $008123
 
 ;################################################
 ;# FREESPACE
@@ -795,8 +831,9 @@ freespace ram
 freespace noram, ram            ; Only one of these are supported at the same time
 freecode cleaned, static
 freedata align
-freedata $00                    ; Values are supported
+freedata $00                    ; Values are supported, but deprecated in favour of freespacebyte
 freedata cleaned, $00
+freespacebyte $00
 
 ; autoclean/prot directives
 ; Scope: keyword.asar.freespace.misc
@@ -831,6 +868,9 @@ base off
 base !ram_define
 skip 
 skip 12
+skip align 16
+skip align 16 offset 5
+skip align $20 offset $17
 warnpc
 warnpc 1
 warnpc $008000
@@ -878,10 +918,10 @@ norom
 
 arch 65816
 arch spc700
-arch spc700-inline
+arch spc700-inline          ; Invalid
 arch superfx
 
-arch spc700-inli            ; Incomplete, doesn't work
+arch spc70                  ; Incomplete, doesn't work
 arch                        ; Must specify an architecture in order to work
 
 ;################################################
@@ -901,6 +941,7 @@ namespace nested off
 
 ;@xkas                      ; No special highlight
 @asar                       ; Highlight doesn't work
+asar 1.91
 
 ;################################################
 ;# CHECKS
@@ -909,8 +950,10 @@ namespace nested off
 ; Scope: keyword.asar.checks
 
 check title "string"
-check bankcross on
+check bankcross on          ; Invalid
 check bankcross off
+check bankcross half
+check bankcross full
 
 ;################################################
 ;# WARNINGS
@@ -922,6 +965,6 @@ warnings push
 warnings pull 
 warnings                    ; Invalid
 
-warnings enable W1012
-warnings disable W1012
-warnings enable 1012        ; Invalid
+warnings enable Wfreespace_leaked
+warnings disable Wfreespace_leaked
+warnings enable freespace_leaked ; Invalid

--- a/user-settings/default.json
+++ b/user-settings/default.json
@@ -392,6 +392,14 @@
                     "fontStyle": "italic"
                 }
             },
+            {
+                "name": "Asar macro variadic argument usage",
+                "scope": "keyword.asar.macro.args.usage.variadic",
+                "settings": {
+                    "foreground": "#45b397",
+                    "fontStyle": "italic"
+                }
+            },
 
 
 
@@ -401,6 +409,14 @@
             {
                 "name": "Asar structs",
                 "scope": "keyword.asar.struct",
+                "settings": {
+                    "foreground": "#dd726b"
+                }
+            },
+
+            {
+                "name": "Asar SPC blocks",
+                "scope": "keyword.asar.spcblock",
                 "settings": {
                     "foreground": "#dd726b"
                 }


### PR DESCRIPTION
Apologies in advance if I've done anything incorrectly or missed anything.
This PR adds syntax highlighting for the new features in the 1.91 release (changelog [here](https://rpghacker.github.io/asar/asar_19/changelog/index.html)) and bumps the version number of the extension.